### PR TITLE
perl-try-tiny: use relative include of perlmod.mk

### DIFF
--- a/lang/perl-try-tiny/Makefile
+++ b/lang/perl-try-tiny/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-try-tiny
 PKG_VERSION:=0.30
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://cpan.metacpan.org/authors/id/E/ET/ETHER/
 PKG_SOURCE:=Try-Tiny-$(PKG_VERSION).tar.gz
@@ -21,7 +21,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/perl/perlmod.mk
+include ../perl/perlmod.mk
 
 define Package/perl-try-tiny
   SUBMENU:=Perl


### PR DESCRIPTION
The $(TOPDIR) seems to cause intermittent issues on with CI.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

Maintainer: me
Compile tested: x86_64
Run tested: N/A

Description:

Intermittent Makefile parsing errors are seen in CI, this is the only thing that I think may cause them.