### PR TITLE
pps-tools: use %lld in printf for 64-bit time_t

### DIFF
--- a/utils/pps-tools/Makefile
+++ b/utils/pps-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pps-tools
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/redlab-i/pps-tools/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/utils/pps-tools/patches/001-time_t_64bit.patch
+++ b/utils/pps-tools/patches/001-time_t_64bit.patch
@@ -1,0 +1,31 @@
+--- a/ppstest.c
++++ b/ppstest.c
+@@ -110,13 +110,13 @@ retry:
+ 	}
+ 
+ 	printf("source %d - "
+-	       "assert %ld.%09ld, sequence: %ld - "
+-	       "clear  %ld.%09ld, sequence: %ld\n",
++	       "assert %lld.%09ld, sequence: %ld - "
++	       "clear  %lld.%09ld, sequence: %ld\n",
+ 	       i,
+-	       infobuf.assert_timestamp.tv_sec,
++	       (long long)infobuf.assert_timestamp.tv_sec,
+ 	       infobuf.assert_timestamp.tv_nsec,
+ 	       infobuf.assert_sequence,
+-	       infobuf.clear_timestamp.tv_sec,
++	       (long long)infobuf.clear_timestamp.tv_sec,
+ 	       infobuf.clear_timestamp.tv_nsec, infobuf.clear_sequence);
+ 	fflush(stdout);
+ 
+--- a/ppswatch.c
++++ b/ppswatch.c
+@@ -145,7 +145,7 @@ int fetch_source(pps_handle_t handle, in
+ 	if (max_divergence < div)
+ 		max_divergence = div;
+ 	if (div >= margin) {
+-		printf("timestamp: %ld, sequence: %ld, offset: % 6ld\n", ts.tv_sec, seq, ts.tv_nsec);
++		printf("timestamp: %lld, sequence: %ld, offset: % 6ld\n", (long long)ts.tv_sec, seq, ts.tv_nsec);
+ 		fflush(stdout);
+ 		overflows++;
+ 		curr_unsync++;


### PR DESCRIPTION
musl 1.2.0 switched to use 64-bit time_t everywhere, including 32-bit architectures, causing garbage values to be printed from ppswatch and ppstest.

Use the correct format string for the affected printf statements and explicitly cast to long long to avoid potential compatibility issues with 32-bit glibc.

Maintainer: @MASHtm 
Compile tested: arm, cloudengines_pogoe02, 23.05.0
Run tested: arm, cloudengines_pogoe02, 23.05.0